### PR TITLE
fix reverse-proxy testnet foo

### DIFF
--- a/html/ui/js/nrs.js
+++ b/html/ui/js/nrs.js
@@ -71,11 +71,11 @@ var NRS = (function(NRS, $, undefined) {
 	var isScanning = false;
 
 	NRS.init = function() {
-		if (window.location.port && window.location.port != "6876") {
-			$(".testnet_only").hide();
-		} else {
+		if (window.location.port != "6876") {
 			NRS.isTestNet = true;
 			$(".testnet_only, #testnet_login, #testnet_warning").show();
+		} else {
+			$(".testnet_only").hide();
 		}
 
 		if (!NRS.server) {


### PR DESCRIPTION
I'm hosting my wallet behind a reverse-proxy server. It adds SSL termination and exposes the apiserver on port 443. In the browser it is called like https://mywallet.com.

Now that there is no port in the URL the UI connects against the Testnet port, due an unfortunate check that fails if no port is given.

This patch fixes this problem and makes the intention clear, that only with the special testnet port the UI connects to Testnet.