### PR TITLE
Fixed issue with some pass phrases not able to assign rewards

### DIFF
--- a/html/ui/rewardassignment.html
+++ b/html/ui/rewardassignment.html
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
 <html>
+<head>
+<meta charset="UTF-8" />
+</head>
 <body>
 Get reward recipient:<br />
 <form method="post" action="/burst">


### PR DESCRIPTION
I found this problem since my pass phrase had a "`" in it, but might help others with some other special characters in it.